### PR TITLE
Query ENS names both by owner and by resolved address

### DIFF
--- a/site/lib/hooks/useENSNames/query.ts
+++ b/site/lib/hooks/useENSNames/query.ts
@@ -2,7 +2,10 @@ import { gql } from 'graphql-request';
 
 export const queryDomains = gql`
 	query queryDomains($owner: String!) {
-		domains(first: 1000, where: { owner_: { id: $owner } }) {
+		domains(
+			first: 1000
+			where: { or: [{ owner: $owner }, { resolvedAddress: $owner }] }
+		) {
 			id
 			name
 			labelName


### PR DESCRIPTION
Fixes #102 by also searching by `resolvedAddress` when querying TheGraph.